### PR TITLE
Rendering fixes for olcPGEX_ViewPort

### DIFF
--- a/olcPGEX_ViewPort.h
+++ b/olcPGEX_ViewPort.h
@@ -195,11 +195,7 @@ void olc::ViewPort::DrawPartialDecal(const olc::vf2d &pos,
                                      const olc::vf2d &source_size,
                                      const olc::vf2d &scale,
                                      const olc::Pixel &tint) const {
-    auto size = olc::vf2d{static_cast<float>(decal->sprite->width),
-                          static_cast<float>(decal->sprite->height)}
-                * scale;
-
-    DrawPartialDecal(pos, size, decal, source_pos, source_size, tint);
+    DrawPartialDecal(pos, source_size * scale, decal, source_pos, source_size, tint);
 }
 
 void olc::ViewPort::DrawPartialDecal(const vf2d &pos,

--- a/olcPGEX_ViewPort.h
+++ b/olcPGEX_ViewPort.h
@@ -360,7 +360,7 @@ void olc::ViewPort::FillRectDecal(const vf2d &pos,
             pos,
             {pos.x, pos.y + size.y},
             pos + size,
-            {pos.x + size.y, pos.y},
+            {pos.x + size.x, pos.y},
     };
     std::vector<vf2d> uvs{
             {0, 0},
@@ -382,7 +382,7 @@ void olc::ViewPort::GradientFillRectDecal(const vf2d &pos,
             pos,
             {pos.x, pos.y + size.y},
             pos + size,
-            {pos.x + size.y, pos.y},
+            {pos.x + size.x, pos.y},
     };
 
     std::vector<vf2d> uvs{

--- a/olcPGEX_ViewPort.h
+++ b/olcPGEX_ViewPort.h
@@ -403,7 +403,7 @@ void olc::ViewPort::GradientFillRectDecal(const vf2d &pos,
             colTR,
     };
 
-    drawClippedDecal(nullptr, points.data(), uvs.data(), colors.data());
+    drawClippedDecal(nullptr, points.data(), uvs.data(), colors.data(), points.size());
 }
 
 void olc::ViewPort::DrawPolygonDecal(Decal *decal,
@@ -416,7 +416,7 @@ void olc::ViewPort::DrawPolygonDecal(Decal *decal,
         colors[i] = tint;
     }
 
-    drawClippedDecal(decal, pos.data(), uv.data(), colors.data());
+    drawClippedDecal(decal, pos.data(), uv.data(), colors.data(), pos.size());
 }
 
 void olc::ViewPort::DrawPolygonDecal(Decal *decal,
@@ -431,7 +431,7 @@ void olc::ViewPort::DrawPolygonDecal(Decal *decal,
                                      const std::vector<vf2d> &pos,
                                      const std::vector<vf2d> &uv,
                                      const std::vector<Pixel> &tint) const {
-    drawClippedDecal(decal, pos.data(), uv.data(), tint.data());
+    drawClippedDecal(decal, pos.data(), uv.data(), tint.data(), pos.size());
 }
 
 void olc::ViewPort::DrawLineDecal(const vf2d &pos1,
@@ -459,7 +459,7 @@ void olc::ViewPort::DrawLineDecal(const vf2d &pos1,
         }
     }
 
-    pge->DrawLineDecal(posA, posB, p);
+    pge->DrawLineDecal(posA + offset, posB + offset, p);
 }
 
 void olc::ViewPort::drawClippedDecal(Decal *decal,


### PR DESCRIPTION
`DrawLineDecal` was missing the `offset` parameter so lines drawn by it were properly clipped, but not moved to the correct location.

`drawClippedDecal` defines the default number of points as 0, and `DrawPolygonDecal` did not include the parameter, so any function that relied on it wasn't rendering.