### PR TITLE
Fix clipping checks not respecting clipping areas with >4 points

### DIFF
--- a/olcPGEX_ViewPort.h
+++ b/olcPGEX_ViewPort.h
@@ -14,6 +14,7 @@ namespace olc {
     class ViewPort : public olc::PGEX {
     public:
         ViewPort();
+        //Define a set of vertices to construct this viewport with. Winding order is counter-clockwise.
         ViewPort(std::vector<vf2d> vertices, vf2d offset = {0, 0});
         virtual ~ViewPort();
         void addPoint(vf2d point);
@@ -570,7 +571,7 @@ void olc::ViewPort::drawClippedDecal(Decal *decal,
 
     for (auto i = 0u; i < clipVertices.size(); i++) {
         auto clipA = clipVertices[i];
-        auto clipB = clipVertices[(i + 1) % 4];
+        auto clipB = clipVertices[(i + 1) % clipVertices.size()];
 
         auto inputList{outputList};
         auto inputUvs{outputUvs};
@@ -640,7 +641,7 @@ void olc::ViewPort::drawClippedPolygonDecal(Decal *decal,
 
     for (auto i = 0u; i < clipVertices.size(); i++) {
         auto clipA = clipVertices[i];
-        auto clipB = clipVertices[(i + 1) % 4];
+        auto clipB = clipVertices[(i + 1) % clipVertices.size()];
 
         auto inputList{outputList};
         auto inputUvs{outputUvs};


### PR DESCRIPTION
For clipping regions with more than 4 sides, this ensures that they are all checked properly so that any amount of clipping vertices should work now. It was just hardcoded in a few spots.

**Before:**
![image](https://github.com/gorbit99/olcPGEX_ViewPort/assets/5907101/0870c903-fc05-44ab-8dde-dc18ac001a08)

**After:**
![image](https://github.com/gorbit99/olcPGEX_ViewPort/assets/5907101/2f409434-f290-47e3-bdf5-7230b91440b4)
